### PR TITLE
add package.json info, link to hot-rld

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # choo-resume
 
-choo-resume + hot-rld = hot app reload in choo 🔥
+choo-resume + [hot-rld](https://github.com/bengourley/hot-rld) = hot app reload in choo 🔥
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -4,5 +4,13 @@
   "description": "choo-resume + hot-rld = hot app reload in choo",
   "main": "index.js",
   "author": "Ben Gourley",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bengourley/choo-resume.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bengourley/choo-resume/issues"
+  },
+  "homepage": "https://github.com/bengourley/choo-resume#readme"
 }


### PR DESCRIPTION
Basic repo/bugs/homepage info in package.json makes it easier to use this module (no homepage in package.json means no link on https://www.npmjs.com/package/choo-resume).

Also thought it would be helpful to link to `hot-rld`.

✨ 